### PR TITLE
Adding docker run aviability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:latest as builder
+# Installing UPX and GIT for building hoshinova and ytarchive 
+RUN apt update
+RUN apt install -y upx git
+# Building Hoshinova
+WORKDIR /app/hoshinova
+COPY . .
+RUN make
+# Cloning and Building ytarchive
+RUN git clone https://github.com/Kethsar/ytarchive.git /app/ytarchive
+WORKDIR /app/ytarchive
+RUN go build
+
+FROM alpine:latest
+RUN mkdir /app
+# Copying executables
+COPY --from=builder /app/hoshinova/hoshinova /app/
+COPY --from=builder /app/ytarchive/ytarchive /app/
+# Adding ytarchive and hoshinova to PATH
+ENV PATH /app/:$PATH
+# Going to config folder
+WORKDIR /config/
+CMD ls && hoshinova
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN make
 # Cloning and Building ytarchive
 RUN git clone https://github.com/Kethsar/ytarchive.git /app/ytarchive
 WORKDIR /app/ytarchive
-RUN go build
+ENV CGO_ENABLED=0
+RUN go build -ldflags "-X main.Commit=-$(git rev-parse --short HEAD)"
 
 FROM alpine:latest
 RUN mkdir /app
@@ -20,5 +21,4 @@ COPY --from=builder /app/ytarchive/ytarchive /app/
 ENV PATH /app/:$PATH
 # Going to config folder
 WORKDIR /config/
-CMD ls && hoshinova
-
+CMD hoshinova

--- a/README.md
+++ b/README.md
@@ -111,3 +111,18 @@ If you used `go install`,
 ```
 ~/go/bin/hoshinova
 ```
+
+### Running in Docker (optional)
+
+Make shure you have [installed Docker Engine](https://docs.docker.com/engine/install/)
+
+Run image in Docker with this command.
+```bash
+docker run -v /path/to/local/config-folder/:/config/ --name hoshinova-container holoarchivist/hoshinova
+```
+> Don't forger to change `/path/to/local/config-folder/` to your local folder with config.yaml
+
+You can check logs with `docker logs` command
+```bash
+docker logs -f hoshinova-container
+```


### PR DESCRIPTION
Hi there! 

Hoshinova is greate service, so I think it should have aviability to be runned over Docker Engine. 
In this pull request I added Dockerfile and updated Readme with instruction

After closing this pull request, there will be need in creation Account on [Docker hub](https://hub.docker.com/) and build + push this image to it.

You can automatise it with Github action, let me know, if you will need help with this)))

