### PR TITLE
Trim the beginning of output line for newer versions of ytarchive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea
+
 /target
+
 config.toml

--- a/src/module/recorder.rs
+++ b/src/module/recorder.rs
@@ -482,8 +482,7 @@ impl YTAStatus {
         // 2024/04/16 16:25:31
         let timestamp_re = Regex::new(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
             .expect("Failed to compile regex for detecting yta output timestamp");
-        let line = if line.len() > 20 && timestamp_re.is_match(line)
-        {
+        let line = if line.len() > 20 && timestamp_re.is_match(line) {
             line[20..].trim()
         } else {
             line

--- a/src/module/recorder.rs
+++ b/src/module/recorder.rs
@@ -478,9 +478,11 @@ impl YTAStatus {
         }
 
         // New versions of ytarchive prepend a timestamp to the output
-        let line = if self.version == Some("0.3.2".into())
-            && line.len() > 20
-            && line.chars().nth(4) == Some('/')
+        // Sample line
+        // 2024/04/16 16:25:31
+        let timestamp_re = Regex::new(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
+            .expect("Failed to compile regex for detecting yta output timestamp");
+        let line = if line.len() > 20 && timestamp_re.is_match(line)
         {
             line[20..].trim()
         } else {

--- a/src/module/recorder.rs
+++ b/src/module/recorder.rs
@@ -480,9 +480,11 @@ impl YTAStatus {
         // New versions of ytarchive prepend a timestamp to the output
         // Sample line
         // 2024/04/16 16:25:31
-        let timestamp_re = Regex::new(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
-            .expect("Failed to compile regex for detecting yta output timestamp");
-        let line = if line.len() > 20 && timestamp_re.is_match(line) {
+        lazy_static! {
+            static ref TIMESTAMP_RE: Regex = Regex::new(r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
+                .expect("Failed to compile regex for detecting yta output timestamp");
+        }
+        let line = if line.len() > 20 && TIMESTAMP_RE.is_match(line) {
             line[20..].trim()
         } else {
             line


### PR DESCRIPTION
Since the newer versions of ytarchive prepend a timestamp to the output, but current mechanism to detect such timestamp are depending on ytarchive's version and being hard-coded to version 0.3.2 
https://github.com/HoloArchivists/hoshinova/blob/f97c92c0932bc7bd2041ae80ae2db34839a66941/src/module/recorder.rs#L481

When I trying to run hoshinova with the latest version of ytartchive (0.4.0-77c2f5c) there are bunch of warning
![Screenshot 2024-04-16 115844](https://github.com/HoloArchivists/hoshinova/assets/86680163/e01c2a07-7958-4104-a4d5-d4bb90e22c25)
![Screenshot 2024-04-16 093235](https://github.com/HoloArchivists/hoshinova/assets/86680163/e8bd1d38-13f3-4d24-9ef3-76a77bc2786d)
and not recording properly (i.e. restart recording immediately after the previous run was ended)
![image](https://github.com/HoloArchivists/hoshinova/assets/86680163/dc330185-c8e5-47c1-9b21-8fa18ee65a47)

This is after my fix:
![image](https://github.com/HoloArchivists/hoshinova/assets/86680163/2a911301-f2d9-4178-8ec5-73da28e6edd2)
and the problem seems to be improved (detecting new streams properly)
![image](https://github.com/HoloArchivists/hoshinova/assets/86680163/3f485a90-935d-4acc-b33a-f20bb8413672)